### PR TITLE
feat: add logout route

### DIFF
--- a/backend/new/options/session_options.js
+++ b/backend/new/options/session_options.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const pool = require ('../db/pool');
+const {authenticate} = require ('../middleware/auth');
+
+const router = express.Router();
+
+
+router.post('/logout', authenticate, async (req, res) => {
+    res.status(200).json ({message: 'logged out successfully'});
+});
+
+module.exports = router;

--- a/backend/new/server.js
+++ b/backend/new/server.js
@@ -9,12 +9,17 @@ const path = require("path");
 const Case = require("./models/Case");
 const authOptions = require('./options/auth_options');
 const { authenticate, authorize } = require('./middleware/auth');
+const sessionOptions = require('./options/session_options');
+
+
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 app.use('/auth', authOptions);
+app.use('/session', sessionOptions);
+
 
 mongoose.connect(process.env.MONGO_URI);
 


### PR DESCRIPTION
- New route: POST /session/logout

- Uses the existing authenticate middleware to confirm the request carries a valid token before confirming logout

- Per team decision (multiple devices allowed, JWTs with 24h expiration, no refresh tokens/device restrictions), token invalidation isn't handled server-side — the actual logout (removing the stored token) happens client-side on the frontend

- Tested manually via curl: signup → login → logout, all returning expected responses

Base branch set to feature/Authentication-Authorization since this depends on middleware/auth.js and the Postgres-based login already built there.