### PR TITLE
Add PostgreSQL data layer and smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ npm run db:ping
 
 You should see something like:
 - `PostgreSQL schema applied.`
-- `users rows: 4` (seed staff accounts)
+- `departments rows: 6`
+- `users rows: 7` (seed staff, maintainers, student)
 - `PostgreSQL OK: ...`
+
+Optional: `npm run db:smoke` exercises create / assign / close through the data layer.
 
 #### Useful commands
 ```bash
@@ -110,13 +113,18 @@ docker compose ps          # container status
 docker compose logs -f     # DB logs
 docker compose down        # stop Postgres
 npm run db:ping            # quick connectivity check
+npm run db:smoke           # data-layer smoke test
 ```
 
 #### What gets created
 | Table | Purpose |
 |--------|---------|
-| `cases` | Tickets (from `models/Case.js`) |
-| `users` | Accounts / roles (from `data/users.json`) |
+| `departments` | Teams tickets can be assigned to |
+| `users` | Students / staff / maintainers / leads |
+| `cases` | Tickets and incidents (location, category, assignment) |
+| `case_events` | Feed and assignment history |
+
+Query helpers live in `backend/new/db/` (`db.users`, `db.cases`, `db.departments`). **Mongo `server.js` is unchanged.**
 
 #### Note before changing `server.js`
 If you plan to switch API routes from Mongo to Postgres, tell the team in the backend chat first so nobody’s local server breaks.

--- a/backend/new/db/README.md
+++ b/backend/new/db/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL base (LGS Tech)
 
-This folder adds the **PostgreSQL foundation** for LGS Tech without replacing the current Mongo-backed `server.js`.
+This folder is the **PostgreSQL foundation** for LGS Tech. The live Express API in `server.js` still uses Mongo (cases) and `data/users.json` until the team switches routes over.
 
 ## Shared credentials (team)
 
@@ -10,12 +10,40 @@ This folder adds the **PostgreSQL foundation** for LGS Tech without replacing th
 | Database | `lgs_tech` |
 | Password | ask in backend chat / local `.env` (`POSTGRES_PASSWORD`) — **do not commit** |
 
-## What maps from `backend/new`
+## Tables
 
-| Current (Mongo / JSON) | PostgreSQL |
-|------------------------|------------|
-| `models/Case.js` | `cases` table (`db/schema.sql`) |
-| `data/users.json` | `users` table |
+| Table | Purpose |
+|--------|---------|
+| `departments` | Assignable teams (Facilities, IT, Engineering, Security, Medical, Estates) |
+| `users` | Students, staff, maintainers, leads (expanded from `users.json`) |
+| `cases` | Tickets / incidents (expanded from Mongo `Case`) |
+| `case_events` | Feed + assignment / status history |
+
+### Users (extra vs JSON)
+
+`college_id`, `department_id`, `year_semester`, `user_type` (`student` / `staff` / `maintainer` / `lead`), `is_active`, `last_login_at`, `updated_at`
+
+### Cases (extra vs Mongo)
+
+`category`, `description`, `chat`, `priority`, `assigned_department_id`, `assigned_user_id`, `created_by_user_id`, `closed_by_user_id`, `closed_at`, `estimated_cost`, emergency-service flags
+
+Status: `ACTIVE` \| `IN_PROGRESS` \| `CLOSED` \| `RESOLVED`  
+Category: Fire, Intruder, Injury, Maintenance, Missing, Facilities, IT Support, Engineering
+
+## Data layer (`db/`)
+
+```js
+const db = require("./db"); // from backend/new
+
+await db.users.listUsers();
+await db.users.getUserByEmail("aisha.khan@student.lgs.ac.uk");
+await db.cases.createCase({ title: "Fire Case", locationX: 0.4, locationY: 0.2 });
+await db.cases.assignCase(id, { departmentId: 6, userId: 5 });
+await db.cases.listCases({ openOnly: true });
+await db.cases.analyticsSummary();
+```
+
+Rows are mapped to the current API shape (`createdAt`, `_id`, `"phone number"`, …) so routes can switch later without a frontend rewrite.
 
 ## Quick start (Docker — recommended)
 
@@ -38,7 +66,10 @@ From `backend/new`:
    ```bash
    npm run db:setup
    npm run db:ping
+   npm run db:smoke
    ```
+
+`db:setup` is idempotent — it adds new columns/tables on an existing volume.
 
 ## Local Windows PostgreSQL install
 
@@ -49,4 +80,4 @@ From `backend/new`:
 ## Note for the team
 
 **Mongo `server.js` is still the live local API.**  
-PostgreSQL is the new DB base. When we switch routes over, we’ll say so in the backend chat before changing `server.js`.
+When we switch `/cases` and `/users` to this data layer, say so in the backend chat first.

--- a/backend/new/db/index.js
+++ b/backend/new/db/index.js
@@ -1,0 +1,19 @@
+/**
+ * PostgreSQL data layer for LGS Tech.
+ * Live Express routes in server.js still use Mongo / users.json until the team switches.
+ *
+ *   const db = require("./db");
+ *   await db.cases.listCases({ openOnly: true });
+ */
+
+const pool = require("./pool");
+const departments = require("./queries/departments");
+const users = require("./queries/users");
+const cases = require("./queries/cases");
+
+module.exports = {
+  pool,
+  departments,
+  users,
+  cases,
+};

--- a/backend/new/db/mappers.js
+++ b/backend/new/db/mappers.js
@@ -1,0 +1,108 @@
+/**
+ * Map Postgres rows to the shapes Express / Expo already use
+ * (camelCase + Mongo-style `_id` on cases, spaced phone key on users).
+ */
+
+function userToApi(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    username: row.username,
+    password: row.password,
+    email: row.email,
+    name: row.name,
+    phone: row.phone,
+    "phone number": row.phone,
+    role: row.role,
+    authorisation: row.authorisation,
+    collegeId: row.college_id,
+    departmentId: row.department_id,
+    department: row.department_name ?? null,
+    yearSemester: row.year_semester,
+    userType: row.user_type,
+    isActive: row.is_active,
+    lastLoginAt: row.last_login_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function departmentToApi(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    kind: row.kind,
+    isActive: row.is_active,
+  };
+}
+
+function caseToApi(row) {
+  if (!row) return null;
+  const id = row.id;
+  return {
+    _id: id,
+    id,
+    title: row.title,
+    createdAt: row.created_at != null ? Number(row.created_at) : null,
+    lastUpdatedAt:
+      row.last_updated_at != null ? Number(row.last_updated_at) : null,
+    status: row.status,
+    locationX: row.location_x,
+    locationY: row.location_y,
+    locationLabel: row.location_label,
+    feed: row.feed ?? "",
+    chat: row.chat ?? "",
+    category: row.category,
+    description: row.description,
+    priority: row.priority,
+    assignedDepartmentId: row.assigned_department_id,
+    assignedDepartmentName: row.assigned_department_name ?? null,
+    assignedUserId: row.assigned_user_id,
+    assignedUserName: row.assigned_user_name ?? null,
+    createdByUserId: row.created_by_user_id,
+    createdByName: row.created_by_name ?? null,
+    closedByUserId: row.closed_by_user_id,
+    closedAt: row.closed_at != null ? Number(row.closed_at) : null,
+    estimatedCost:
+      row.estimated_cost != null ? Number(row.estimated_cost) : null,
+    policeContacted: row.police_contacted,
+    fireContacted: row.fire_contacted,
+    ambulanceContacted: row.ambulance_contacted,
+    maintenanceContacted: row.maintenance_contacted,
+  };
+}
+
+function eventToApi(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    caseId: row.case_id,
+    userId: row.user_id,
+    userName: row.user_name ?? null,
+    eventType: row.event_type,
+    message: row.message,
+    createdAt: row.created_at != null ? Number(row.created_at) : null,
+  };
+}
+
+function nowMs() {
+  return Date.now();
+}
+
+function pick(body, camel, snake) {
+  if (body == null) return undefined;
+  if (Object.prototype.hasOwnProperty.call(body, camel)) return body[camel];
+  if (Object.prototype.hasOwnProperty.call(body, snake)) return body[snake];
+  return undefined;
+}
+
+module.exports = {
+  userToApi,
+  departmentToApi,
+  caseToApi,
+  eventToApi,
+  nowMs,
+  pick,
+};

--- a/backend/new/db/queries/cases.js
+++ b/backend/new/db/queries/cases.js
@@ -1,0 +1,410 @@
+const { query } = require("../pool");
+const { caseToApi, eventToApi, nowMs, pick } = require("../mappers");
+
+const CASE_SELECT = `
+  SELECT
+    c.id,
+    c.title,
+    c.created_at,
+    c.last_updated_at,
+    c.status,
+    c.location_x,
+    c.location_y,
+    c.location_label,
+    c.feed,
+    c.category,
+    c.description,
+    c.chat,
+    c.priority,
+    c.assigned_department_id,
+    d.name AS assigned_department_name,
+    c.assigned_user_id,
+    au.name AS assigned_user_name,
+    c.created_by_user_id,
+    cu.name AS created_by_name,
+    c.closed_by_user_id,
+    c.closed_at,
+    c.estimated_cost,
+    c.police_contacted,
+    c.fire_contacted,
+    c.ambulance_contacted,
+    c.maintenance_contacted
+  FROM cases c
+  LEFT JOIN departments d ON d.id = c.assigned_department_id
+  LEFT JOIN users au ON au.id = c.assigned_user_id
+  LEFT JOIN users cu ON cu.id = c.created_by_user_id
+`;
+
+function categoryFromTitle(title) {
+  if (!title || typeof title !== "string") return null;
+  const base = title.replace(/\s+Case$/i, "").trim();
+  const allowed = [
+    "Fire",
+    "Intruder",
+    "Injury",
+    "Maintenance",
+    "Missing",
+    "Facilities",
+    "IT Support",
+    "Engineering",
+  ];
+  return allowed.includes(base) ? base : null;
+}
+
+function formatFeedLine(message) {
+  return `[${new Date().toLocaleTimeString()}] ${message}`;
+}
+
+async function listCases(filters = {}) {
+  const clauses = [];
+  const params = [];
+  const {
+    status,
+    category,
+    assignedUserId,
+    assignedDepartmentId,
+    createdByUserId,
+    openOnly,
+  } = filters;
+
+  if (openOnly) {
+    clauses.push(`c.status IN ('ACTIVE', 'IN_PROGRESS')`);
+  } else if (status) {
+    params.push(status);
+    clauses.push(`c.status = $${params.length}`);
+  }
+  if (category) {
+    params.push(category);
+    clauses.push(`c.category = $${params.length}`);
+  }
+  if (assignedUserId != null) {
+    params.push(assignedUserId);
+    clauses.push(`c.assigned_user_id = $${params.length}`);
+  }
+  if (assignedDepartmentId != null) {
+    params.push(assignedDepartmentId);
+    clauses.push(`c.assigned_department_id = $${params.length}`);
+  }
+  if (createdByUserId != null) {
+    params.push(createdByUserId);
+    clauses.push(`c.created_by_user_id = $${params.length}`);
+  }
+
+  const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+  const result = await query(
+    `${CASE_SELECT} ${where} ORDER BY c.created_at DESC`,
+    params
+  );
+  return result.rows.map(caseToApi);
+}
+
+async function getCaseById(id) {
+  const result = await query(`${CASE_SELECT} WHERE c.id = $1`, [id]);
+  return caseToApi(result.rows[0]);
+}
+
+function buildCaseFields(body) {
+  const title = pick(body, "title", "title");
+  const categoryExplicit = pick(body, "category", "category");
+  const category =
+    categoryExplicit !== undefined
+      ? categoryExplicit
+      : title !== undefined
+        ? categoryFromTitle(title) || undefined
+        : undefined;
+
+  return {
+    title,
+    created_at: pick(body, "createdAt", "created_at"),
+    last_updated_at: pick(body, "lastUpdatedAt", "last_updated_at"),
+    status: pick(body, "status", "status"),
+    location_x: pick(body, "locationX", "location_x"),
+    location_y: pick(body, "locationY", "location_y"),
+    location_label: pick(body, "locationLabel", "location_label"),
+    feed: pick(body, "feed", "feed"),
+    category,
+    description: pick(body, "description", "description"),
+    chat: pick(body, "chat", "chat"),
+    priority: pick(body, "priority", "priority"),
+    assigned_department_id: pick(body, "assignedDepartmentId", "assigned_department_id"),
+    assigned_user_id: pick(body, "assignedUserId", "assigned_user_id"),
+    created_by_user_id: pick(body, "createdByUserId", "created_by_user_id"),
+    closed_by_user_id: pick(body, "closedByUserId", "closed_by_user_id"),
+    closed_at: pick(body, "closedAt", "closed_at"),
+    estimated_cost: pick(body, "estimatedCost", "estimated_cost"),
+    police_contacted: pick(body, "policeContacted", "police_contacted"),
+    fire_contacted: pick(body, "fireContacted", "fire_contacted"),
+    ambulance_contacted: pick(body, "ambulanceContacted", "ambulance_contacted"),
+    maintenance_contacted: pick(
+      body,
+      "maintenanceContacted",
+      "maintenance_contacted"
+    ),
+  };
+}
+
+async function createCase(body) {
+  const f = buildCaseFields(body);
+  const createdAt = f.created_at ?? nowMs();
+  const lastUpdated = f.last_updated_at ?? createdAt;
+
+  const result = await query(
+    `INSERT INTO cases (
+       title, created_at, last_updated_at, status,
+       location_x, location_y, location_label, feed,
+       category, description, chat, priority,
+       assigned_department_id, assigned_user_id, created_by_user_id,
+       estimated_cost, police_contacted, fire_contacted,
+       ambulance_contacted, maintenance_contacted
+     ) VALUES (
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20
+     )
+     RETURNING id`,
+    [
+      f.title ?? null,
+      createdAt,
+      lastUpdated,
+      f.status ?? "ACTIVE",
+      f.location_x ?? null,
+      f.location_y ?? null,
+      f.location_label ?? null,
+      f.feed ?? "",
+      f.category ?? "Maintenance",
+      f.description ?? null,
+      f.chat ?? "",
+      f.priority ?? "NORMAL",
+      f.assigned_department_id ?? null,
+      f.assigned_user_id ?? null,
+      f.created_by_user_id ?? null,
+      f.estimated_cost ?? null,
+      Boolean(f.police_contacted),
+      Boolean(f.fire_contacted),
+      Boolean(f.ambulance_contacted),
+      Boolean(f.maintenance_contacted),
+    ]
+  );
+
+  const created = await getCaseById(result.rows[0].id);
+  await addCaseEvent(created.id, {
+    eventType: "created",
+    message: `Case opened${f.category ? ` (${f.category})` : ""}`,
+    userId: f.created_by_user_id ?? null,
+  });
+  return getCaseById(created.id);
+}
+
+async function updateCase(id, body) {
+  const f = buildCaseFields(body);
+  const sets = ["last_updated_at = $1"];
+  const params = [nowMs()];
+
+  const columns = [
+    ["title", f.title],
+    ["status", f.status],
+    ["location_x", f.location_x],
+    ["location_y", f.location_y],
+    ["location_label", f.location_label],
+    ["feed", f.feed],
+    ["category", f.category],
+    ["description", f.description],
+    ["chat", f.chat],
+    ["priority", f.priority],
+    ["assigned_department_id", f.assigned_department_id],
+    ["assigned_user_id", f.assigned_user_id],
+    ["created_by_user_id", f.created_by_user_id],
+    ["closed_by_user_id", f.closed_by_user_id],
+    ["closed_at", f.closed_at],
+    ["estimated_cost", f.estimated_cost],
+    ["police_contacted", f.police_contacted],
+    ["fire_contacted", f.fire_contacted],
+    ["ambulance_contacted", f.ambulance_contacted],
+    ["maintenance_contacted", f.maintenance_contacted],
+  ];
+
+  for (const [col, value] of columns) {
+    if (value !== undefined) {
+      params.push(value);
+      sets.push(`${col} = $${params.length}`);
+    }
+  }
+
+  params.push(id);
+  const result = await query(
+    `UPDATE cases SET ${sets.join(", ")} WHERE id = $${params.length} RETURNING id`,
+    params
+  );
+  if (!result.rowCount) return null;
+  return getCaseById(id);
+}
+
+async function deleteCase(id) {
+  const result = await query(`DELETE FROM cases WHERE id = $1`, [id]);
+  return result.rowCount > 0;
+}
+
+async function assignCase(id, { departmentId, userId, actorUserId } = {}) {
+  const existing = await getCaseById(id);
+  if (!existing) return null;
+
+  const nextStatus =
+    existing.status === "CLOSED" || existing.status === "RESOLVED"
+      ? existing.status
+      : "IN_PROGRESS";
+
+  const updated = await updateCase(id, {
+    assignedDepartmentId: departmentId ?? existing.assignedDepartmentId,
+    assignedUserId: userId ?? existing.assignedUserId,
+    status: nextStatus,
+  });
+
+  const parts = [];
+  if (departmentId != null) parts.push(`department ${departmentId}`);
+  if (userId != null) parts.push(`user ${userId}`);
+  await addCaseEvent(id, {
+    eventType: "assignment",
+    message: `Assigned to ${parts.join(" / ") || "unspecified"}`,
+    userId: actorUserId ?? null,
+  });
+  return getCaseById(updated.id);
+}
+
+async function closeCase(id, { actorUserId, status = "CLOSED" } = {}) {
+  const existing = await getCaseById(id);
+  if (!existing) return null;
+  await updateCase(id, {
+    status,
+    closedAt: nowMs(),
+    closedByUserId: actorUserId ?? null,
+  });
+  await addCaseEvent(id, {
+    eventType: "closed",
+    message: `Case ${status.toLowerCase()}`,
+    userId: actorUserId ?? null,
+  });
+  return getCaseById(id);
+}
+
+async function reopenCase(id, { actorUserId } = {}) {
+  const existing = await getCaseById(id);
+  if (!existing) return null;
+  await updateCase(id, {
+    status: "ACTIVE",
+    closedAt: null,
+    closedByUserId: null,
+  });
+  await addCaseEvent(id, {
+    eventType: "reopened",
+    message: "Case reopened",
+    userId: actorUserId ?? null,
+  });
+  return getCaseById(id);
+}
+
+async function addCaseEvent(caseId, { message, eventType = "note", userId } = {}) {
+  if (!message) throw new Error("event message is required");
+
+  const createdAt = nowMs();
+  const line = formatFeedLine(message);
+
+  await query(
+    `INSERT INTO case_events (case_id, user_id, event_type, message, created_at)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [caseId, userId ?? null, eventType, message, createdAt]
+  );
+
+  await query(
+    `UPDATE cases
+     SET feed = CASE
+           WHEN feed IS NULL OR feed = '' THEN $2
+           ELSE feed || E'\n' || $2
+         END,
+         last_updated_at = $3
+     WHERE id = $1`,
+    [caseId, line, createdAt]
+  );
+
+  const result = await query(
+    `SELECT e.*, u.name AS user_name
+     FROM case_events e
+     LEFT JOIN users u ON u.id = e.user_id
+     WHERE e.case_id = $1
+     ORDER BY e.created_at DESC
+     LIMIT 1`,
+    [caseId]
+  );
+  return eventToApi(result.rows[0]);
+}
+
+async function listCaseEvents(caseId) {
+  const result = await query(
+    `SELECT e.*, u.name AS user_name
+     FROM case_events e
+     LEFT JOIN users u ON u.id = e.user_id
+     WHERE e.case_id = $1
+     ORDER BY e.created_at ASC`,
+    [caseId]
+  );
+  return result.rows.map(eventToApi);
+}
+
+async function analyticsSummary() {
+  const [overview, byCategory, hotspots, services] = await Promise.all([
+    query(`
+      SELECT
+        COUNT(*) FILTER (WHERE status IN ('ACTIVE', 'IN_PROGRESS'))::int AS active,
+        COUNT(*) FILTER (WHERE status IN ('CLOSED', 'RESOLVED'))::int AS closed,
+        COUNT(*)::int AS total,
+        COALESCE(
+          AVG(closed_at - created_at) FILTER (WHERE closed_at IS NOT NULL),
+          0
+        )::bigint AS avg_duration_ms
+      FROM cases
+    `),
+    query(`
+      SELECT category, COUNT(*)::int AS count
+      FROM cases
+      GROUP BY category
+      ORDER BY count DESC
+    `),
+    query(`
+      SELECT COALESCE(NULLIF(location_label, ''), '(unlabelled)') AS label,
+             COUNT(*)::int AS count
+      FROM cases
+      GROUP BY 1
+      ORDER BY count DESC
+      LIMIT 10
+    `),
+    query(`
+      SELECT
+        COUNT(*) FILTER (WHERE police_contacted)::int AS police,
+        COUNT(*) FILTER (WHERE fire_contacted)::int AS fire,
+        COUNT(*) FILTER (WHERE ambulance_contacted)::int AS ambulance,
+        COUNT(*) FILTER (WHERE maintenance_contacted)::int AS maintenance
+      FROM cases
+    `),
+  ]);
+
+  return {
+    active: overview.rows[0].active,
+    closed: overview.rows[0].closed,
+    total: overview.rows[0].total,
+    avgDurationMs: Number(overview.rows[0].avg_duration_ms) || 0,
+    byCategory: byCategory.rows,
+    hotspots: hotspots.rows,
+    servicesContacted: services.rows[0],
+  };
+}
+
+module.exports = {
+  listCases,
+  getCaseById,
+  createCase,
+  updateCase,
+  deleteCase,
+  assignCase,
+  closeCase,
+  reopenCase,
+  addCaseEvent,
+  listCaseEvents,
+  analyticsSummary,
+};

--- a/backend/new/db/queries/departments.js
+++ b/backend/new/db/queries/departments.js
@@ -1,0 +1,34 @@
+const { query } = require("../pool");
+const { departmentToApi } = require("../mappers");
+
+const COLS = `id, name, slug, kind, is_active`;
+
+async function listDepartments({ activeOnly = true } = {}) {
+  const sql = activeOnly
+    ? `SELECT ${COLS} FROM departments WHERE is_active = TRUE ORDER BY name`
+    : `SELECT ${COLS} FROM departments ORDER BY name`;
+  const result = await query(sql);
+  return result.rows.map(departmentToApi);
+}
+
+async function getDepartmentById(id) {
+  const result = await query(
+    `SELECT ${COLS} FROM departments WHERE id = $1`,
+    [id]
+  );
+  return departmentToApi(result.rows[0]);
+}
+
+async function getDepartmentByName(name) {
+  const result = await query(
+    `SELECT ${COLS} FROM departments WHERE LOWER(name) = LOWER($1) LIMIT 1`,
+    [name]
+  );
+  return departmentToApi(result.rows[0]);
+}
+
+module.exports = {
+  listDepartments,
+  getDepartmentById,
+  getDepartmentByName,
+};

--- a/backend/new/db/queries/users.js
+++ b/backend/new/db/queries/users.js
@@ -1,0 +1,183 @@
+const { query } = require("../pool");
+const { userToApi, nowMs, pick } = require("../mappers");
+
+const USER_SELECT = `
+  SELECT
+    u.id,
+    u.username,
+    u.password,
+    u.email,
+    u.name,
+    u.phone,
+    u.role,
+    u.authorisation,
+    u.college_id,
+    u.department_id,
+    d.name AS department_name,
+    u.year_semester,
+    u.user_type,
+    u.is_active,
+    u.last_login_at,
+    u.created_at,
+    u.updated_at
+  FROM users u
+  LEFT JOIN departments d ON d.id = u.department_id
+`;
+
+async function listUsers({ userType, departmentId, activeOnly = true } = {}) {
+  const clauses = [];
+  const params = [];
+
+  if (activeOnly) {
+    clauses.push("u.is_active = TRUE");
+  }
+  if (userType) {
+    params.push(userType);
+    clauses.push(`u.user_type = $${params.length}`);
+  }
+  if (departmentId != null) {
+    params.push(departmentId);
+    clauses.push(`u.department_id = $${params.length}`);
+  }
+
+  const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+  const result = await query(
+    `${USER_SELECT} ${where} ORDER BY u.id`,
+    params
+  );
+  return result.rows.map(userToApi);
+}
+
+async function getUserById(id) {
+  const result = await query(`${USER_SELECT} WHERE u.id = $1`, [id]);
+  return userToApi(result.rows[0]);
+}
+
+async function getUserByEmail(email) {
+  const result = await query(
+    `${USER_SELECT} WHERE LOWER(u.email) = LOWER($1) LIMIT 1`,
+    [email]
+  );
+  return userToApi(result.rows[0]);
+}
+
+async function getUserByUsername(username) {
+  const result = await query(
+    `${USER_SELECT} WHERE LOWER(u.username) = LOWER($1) LIMIT 1`,
+    [username]
+  );
+  return userToApi(result.rows[0]);
+}
+
+function buildUserFields(body) {
+  const phone = pick(body, "phone", "phone") ?? body["phone number"];
+  return {
+    username: pick(body, "username", "username"),
+    password: pick(body, "password", "password"),
+    email: pick(body, "email", "email"),
+    name: pick(body, "name", "name"),
+    phone,
+    role: pick(body, "role", "role"),
+    authorisation: pick(body, "authorisation", "authorisation"),
+    college_id: pick(body, "collegeId", "college_id"),
+    department_id: pick(body, "departmentId", "department_id"),
+    year_semester: pick(body, "yearSemester", "year_semester"),
+    user_type: pick(body, "userType", "user_type"),
+    is_active: pick(body, "isActive", "is_active"),
+  };
+}
+
+async function createUser(body) {
+  const f = buildUserFields(body);
+  if (!f.username || !f.password || !f.email) {
+    throw new Error("username, password, and email are required");
+  }
+
+  const result = await query(
+    `INSERT INTO users (
+       username, password, email, name, phone, role, authorisation,
+       college_id, department_id, year_semester, user_type, is_active
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+     RETURNING id`,
+    [
+      f.username,
+      f.password,
+      f.email,
+      f.name ?? null,
+      f.phone ?? null,
+      f.role ?? null,
+      f.authorisation ?? 2,
+      f.college_id ?? null,
+      f.department_id ?? null,
+      f.year_semester ?? null,
+      f.user_type ?? "staff",
+      f.is_active !== false,
+    ]
+  );
+  return getUserById(result.rows[0].id);
+}
+
+async function updateUser(id, body) {
+  const f = buildUserFields(body);
+  const sets = ["updated_at = NOW()"];
+  const params = [];
+
+  const columns = [
+    ["username", f.username],
+    ["password", f.password],
+    ["email", f.email],
+    ["name", f.name],
+    ["phone", f.phone],
+    ["role", f.role],
+    ["authorisation", f.authorisation],
+    ["college_id", f.college_id],
+    ["department_id", f.department_id],
+    ["year_semester", f.year_semester],
+    ["user_type", f.user_type],
+    ["is_active", f.is_active],
+  ];
+
+  for (const [col, value] of columns) {
+    if (value !== undefined) {
+      params.push(value);
+      sets.push(`${col} = $${params.length}`);
+    }
+  }
+
+  params.push(id);
+  const result = await query(
+    `UPDATE users SET ${sets.join(", ")} WHERE id = $${params.length} RETURNING id`,
+    params
+  );
+  if (!result.rowCount) return null;
+  return getUserById(id);
+}
+
+async function deleteUser(id) {
+  const result = await query(`DELETE FROM users WHERE id = $1`, [id]);
+  return result.rowCount > 0;
+}
+
+async function recordLogin(id) {
+  await query(
+    `UPDATE users SET last_login_at = NOW(), updated_at = NOW() WHERE id = $1`,
+    [id]
+  );
+  return getUserById(id);
+}
+
+async function listAssignableUsers() {
+  return listUsers({ userType: "maintainer" });
+}
+
+module.exports = {
+  listUsers,
+  getUserById,
+  getUserByEmail,
+  getUserByUsername,
+  createUser,
+  updateUser,
+  deleteUser,
+  recordLogin,
+  listAssignableUsers,
+};

--- a/backend/new/db/schema.sql
+++ b/backend/new/db/schema.sql
@@ -1,9 +1,143 @@
--- LGS Tech PostgreSQL base schema
--- Mirrors backend/new Mongo Case model + Settings users storage
+-- LGS Tech PostgreSQL schema
+-- Campus ticketing: users, departments, cases/incidents, feed events
+-- Idempotent: safe on fresh Docker volumes and existing local DBs (npm run db:setup)
 
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
--- Tickets / cases (replaces Mongo Case collection)
+-- ---------------------------------------------------------------------------
+-- Departments (assign tickets to Facilities / IT / Engineering / …)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS departments (
+  id SERIAL PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL,
+  slug TEXT UNIQUE NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'facilities'
+    CHECK (kind IN ('facilities', 'it', 'engineering', 'security', 'medical', 'other')),
+  is_active BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+INSERT INTO departments (id, name, slug, kind) VALUES
+  (1, 'Facilities', 'facilities', 'facilities'),
+  (2, 'IT Support', 'it-support', 'it'),
+  (3, 'Engineering', 'engineering', 'engineering'),
+  (4, 'Security', 'security', 'security'),
+  (5, 'Medical', 'medical', 'medical'),
+  (6, 'Estates / Maintenance', 'estates', 'facilities')
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval(
+  pg_get_serial_sequence('departments', 'id'),
+  (SELECT COALESCE(MAX(id), 1) FROM departments)
+);
+
+-- ---------------------------------------------------------------------------
+-- Users (students, staff, maintainers, leads)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT,
+  phone TEXT,
+  role TEXT,
+  authorisation INTEGER NOT NULL DEFAULT 2
+    CHECK (authorisation IN (1, 2)),
+  college_id TEXT,
+  department_id INTEGER REFERENCES departments (id),
+  year_semester TEXT,
+  user_type TEXT NOT NULL DEFAULT 'staff'
+    CHECK (user_type IN ('student', 'staff', 'maintainer', 'lead')),
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  last_login_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS college_id TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS department_id INTEGER;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS year_semester TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS user_type TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active BOOLEAN;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+
+UPDATE users SET user_type = 'staff' WHERE user_type IS NULL;
+UPDATE users SET is_active = TRUE WHERE is_active IS NULL;
+UPDATE users SET updated_at = NOW() WHERE updated_at IS NULL;
+UPDATE users SET authorisation = 2 WHERE authorisation IS NULL;
+
+ALTER TABLE users ALTER COLUMN user_type SET DEFAULT 'staff';
+ALTER TABLE users ALTER COLUMN user_type SET NOT NULL;
+ALTER TABLE users ALTER COLUMN is_active SET DEFAULT TRUE;
+ALTER TABLE users ALTER COLUMN is_active SET NOT NULL;
+ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT NOW();
+ALTER TABLE users ALTER COLUMN updated_at SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_department_id_fkey'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_department_id_fkey
+      FOREIGN KEY (department_id) REFERENCES departments (id);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_user_type_check'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_user_type_check
+      CHECK (user_type IN ('student', 'staff', 'maintainer', 'lead'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_authorisation_check'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_authorisation_check
+      CHECK (authorisation IN (1, 2));
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);
+CREATE INDEX IF NOT EXISTS idx_users_department_id ON users (department_id);
+CREATE INDEX IF NOT EXISTS idx_users_user_type ON users (user_type);
+CREATE INDEX IF NOT EXISTS idx_users_college_id ON users (college_id);
+
+-- Seed demo staff (same ids/passwords as data/users.json) plus maintainer + student
+INSERT INTO users (
+  id, username, password, email, name, phone, role, authorisation,
+  user_type, department_id, college_id
+) VALUES
+  (1, 'jimstevens322', 'London588', 'jimstevens@gmail.com', 'Jim',
+    '+4476338674998', 'Art teacher', 2, 'staff', NULL, NULL),
+  (2, 'markdavis99', 'Football456', 'markdavis@gmail.com', 'Mark',
+    '+447658713447', 'Maths teacher', 2, 'staff', NULL, NULL),
+  (3, 'lindsaywilliams1874', 'TableTop22', 'lindsaywilliams@gmail.com', 'Lindsay',
+    '+447566345922', 'Head teacher', 1, 'lead', NULL, NULL),
+  (4, 'ellamcintosh111', 'TableTop22', 'ellamcintosh@gmail.com', 'Ella',
+    '+447455698236', 'English teacher', 2, 'staff', NULL, NULL),
+  (5, 'patel.estates', 'Estates221', 'estates@lgs.ac.uk', 'Priya Patel',
+    '+447400100501', 'Estates maintainer', 2, 'maintainer', 6, 'STAFF-EST-01'),
+  (6, 'chen.it', 'ITSupport19', 'itsupport@lgs.ac.uk', 'Wei Chen',
+    '+447400100502', 'IT technician', 2, 'maintainer', 2, 'STAFF-IT-04'),
+  (7, 'aisha.student', 'Student100', 'aisha.khan@student.lgs.ac.uk', 'Aisha Khan',
+    '+447400100601', 'Student', 2, 'student', NULL, 'LGS-2026-4412')
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE users SET user_type = 'lead', authorisation = 1 WHERE id = 3 AND user_type = 'staff';
+UPDATE users SET department_id = 6 WHERE id = 5 AND department_id IS NULL;
+UPDATE users SET department_id = 2 WHERE id = 6 AND department_id IS NULL;
+
+SELECT setval(
+  pg_get_serial_sequence('users', 'id'),
+  (SELECT COALESCE(MAX(id), 1) FROM users)
+);
+
+-- ---------------------------------------------------------------------------
+-- Cases / incidents (map tickets + emergency cases)
+-- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS cases (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   title TEXT,
@@ -14,34 +148,135 @@ CREATE TABLE IF NOT EXISTS cases (
   location_y DOUBLE PRECISION,
   location_label TEXT,
   feed TEXT,
-  CONSTRAINT cases_status_check CHECK (status IN ('ACTIVE', 'CLOSED', 'RESOLVED'))
+  category TEXT NOT NULL DEFAULT 'Maintenance',
+  description TEXT,
+  chat TEXT,
+  priority TEXT NOT NULL DEFAULT 'NORMAL',
+  assigned_department_id INTEGER REFERENCES departments (id),
+  assigned_user_id INTEGER REFERENCES users (id),
+  created_by_user_id INTEGER REFERENCES users (id),
+  closed_by_user_id INTEGER REFERENCES users (id),
+  closed_at BIGINT,
+  estimated_cost NUMERIC(12, 2),
+  police_contacted BOOLEAN NOT NULL DEFAULT FALSE,
+  fire_contacted BOOLEAN NOT NULL DEFAULT FALSE,
+  ambulance_contacted BOOLEAN NOT NULL DEFAULT FALSE,
+  maintenance_contacted BOOLEAN NOT NULL DEFAULT FALSE
 );
+
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS category TEXT;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS description TEXT;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS chat TEXT;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS priority TEXT;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS assigned_department_id INTEGER;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS assigned_user_id INTEGER;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS closed_by_user_id INTEGER;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS closed_at BIGINT;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS estimated_cost NUMERIC(12, 2);
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS police_contacted BOOLEAN;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS fire_contacted BOOLEAN;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS ambulance_contacted BOOLEAN;
+ALTER TABLE cases ADD COLUMN IF NOT EXISTS maintenance_contacted BOOLEAN;
+
+UPDATE cases SET category = 'Maintenance' WHERE category IS NULL OR category = '';
+UPDATE cases SET priority = 'NORMAL' WHERE priority IS NULL OR priority = '';
+UPDATE cases SET police_contacted = FALSE WHERE police_contacted IS NULL;
+UPDATE cases SET fire_contacted = FALSE WHERE fire_contacted IS NULL;
+UPDATE cases SET ambulance_contacted = FALSE WHERE ambulance_contacted IS NULL;
+UPDATE cases SET maintenance_contacted = FALSE WHERE maintenance_contacted IS NULL;
+
+ALTER TABLE cases ALTER COLUMN category SET DEFAULT 'Maintenance';
+ALTER TABLE cases ALTER COLUMN category SET NOT NULL;
+ALTER TABLE cases ALTER COLUMN priority SET DEFAULT 'NORMAL';
+ALTER TABLE cases ALTER COLUMN priority SET NOT NULL;
+ALTER TABLE cases ALTER COLUMN police_contacted SET DEFAULT FALSE;
+ALTER TABLE cases ALTER COLUMN police_contacted SET NOT NULL;
+ALTER TABLE cases ALTER COLUMN fire_contacted SET DEFAULT FALSE;
+ALTER TABLE cases ALTER COLUMN fire_contacted SET NOT NULL;
+ALTER TABLE cases ALTER COLUMN ambulance_contacted SET DEFAULT FALSE;
+ALTER TABLE cases ALTER COLUMN ambulance_contacted SET NOT NULL;
+ALTER TABLE cases ALTER COLUMN maintenance_contacted SET DEFAULT FALSE;
+ALTER TABLE cases ALTER COLUMN maintenance_contacted SET NOT NULL;
+
+ALTER TABLE cases DROP CONSTRAINT IF EXISTS cases_status_check;
+ALTER TABLE cases ADD CONSTRAINT cases_status_check
+  CHECK (status IN ('ACTIVE', 'IN_PROGRESS', 'CLOSED', 'RESOLVED'));
+
+ALTER TABLE cases DROP CONSTRAINT IF EXISTS cases_category_check;
+ALTER TABLE cases ADD CONSTRAINT cases_category_check
+  CHECK (category IN (
+    'Fire', 'Intruder', 'Injury', 'Maintenance', 'Missing',
+    'Facilities', 'IT Support', 'Engineering'
+  ));
+
+ALTER TABLE cases DROP CONSTRAINT IF EXISTS cases_priority_check;
+ALTER TABLE cases ADD CONSTRAINT cases_priority_check
+  CHECK (priority IN ('LOW', 'NORMAL', 'HIGH', 'CRITICAL'));
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'cases_assigned_department_id_fkey'
+  ) THEN
+    ALTER TABLE cases
+      ADD CONSTRAINT cases_assigned_department_id_fkey
+      FOREIGN KEY (assigned_department_id) REFERENCES departments (id);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'cases_assigned_user_id_fkey'
+  ) THEN
+    ALTER TABLE cases
+      ADD CONSTRAINT cases_assigned_user_id_fkey
+      FOREIGN KEY (assigned_user_id) REFERENCES users (id);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'cases_created_by_user_id_fkey'
+  ) THEN
+    ALTER TABLE cases
+      ADD CONSTRAINT cases_created_by_user_id_fkey
+      FOREIGN KEY (created_by_user_id) REFERENCES users (id);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'cases_closed_by_user_id_fkey'
+  ) THEN
+    ALTER TABLE cases
+      ADD CONSTRAINT cases_closed_by_user_id_fkey
+      FOREIGN KEY (closed_by_user_id) REFERENCES users (id);
+  END IF;
+END
+$$;
 
 CREATE INDEX IF NOT EXISTS idx_cases_status ON cases (status);
 CREATE INDEX IF NOT EXISTS idx_cases_created_at ON cases (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cases_category ON cases (category);
+CREATE INDEX IF NOT EXISTS idx_cases_assigned_user_id ON cases (assigned_user_id);
+CREATE INDEX IF NOT EXISTS idx_cases_assigned_department_id ON cases (assigned_department_id);
+CREATE INDEX IF NOT EXISTS idx_cases_created_by_user_id ON cases (created_by_user_id);
+CREATE INDEX IF NOT EXISTS idx_cases_location_label ON cases (location_label);
 
--- Users (replaces data/users.json used by Settings)
-CREATE TABLE IF NOT EXISTS users (
-  id SERIAL PRIMARY KEY,
-  username TEXT UNIQUE NOT NULL,
-  password TEXT NOT NULL,
-  email TEXT UNIQUE NOT NULL,
-  name TEXT,
-  phone TEXT,
-  role TEXT,
-  authorisation INTEGER NOT NULL DEFAULT 2,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+-- Infer category from existing titles like "Fire Case"
+UPDATE cases
+SET category = regexp_replace(title, '\s+Case$', '')
+WHERE (title ILIKE '% Case')
+  AND regexp_replace(title, '\s+Case$', '') IN (
+    'Fire', 'Intruder', 'Injury', 'Maintenance', 'Missing',
+    'Facilities', 'IT Support', 'Engineering'
+  );
+
+-- ---------------------------------------------------------------------------
+-- Case feed / assignment history (structured; feed TEXT kept for the app)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS case_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id UUID NOT NULL REFERENCES cases (id) ON DELETE CASCADE,
+  user_id INTEGER REFERENCES users (id),
+  event_type TEXT NOT NULL DEFAULT 'note'
+    CHECK (event_type IN (
+      'created', 'note', 'location', 'status', 'assignment', 'services', 'closed', 'reopened'
+    )),
+  message TEXT NOT NULL,
+  created_at BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT
 );
 
-CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);
-
--- Seed demo staff accounts (same shape as previous users.json)
-INSERT INTO users (id, username, password, email, name, phone, role, authorisation)
-VALUES
-  (1, 'jimstevens322', 'London588', 'jimstevens@gmail.com', 'Jim', '+4476338674998', 'Art teacher', 2),
-  (2, 'markdavis99', 'Football456', 'markdavis@gmail.com', 'Mark', '+447658713447', 'Maths teacher', 2),
-  (3, 'lindsaywilliams1874', 'TableTop22', 'lindsaywilliams@gmail.com', 'Lindsay', '+447566345922', 'Head teacher', 1),
-  (4, 'ellamcintosh111', 'TableTop22', 'ellamcintosh@gmail.com', 'Ella', '+447455698236', 'English teacher', 2)
-ON CONFLICT (id) DO NOTHING;
-
-SELECT setval(pg_get_serial_sequence('users', 'id'), (SELECT COALESCE(MAX(id), 1) FROM users));
+CREATE INDEX IF NOT EXISTS idx_case_events_case_id ON case_events (case_id, created_at);

--- a/backend/new/package.json
+++ b/backend/new/package.json
@@ -10,7 +10,8 @@
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
     "db:setup": "node scripts/setup-postgres.js",
-    "db:ping": "node scripts/ping-postgres.js"
+    "db:ping": "node scripts/ping-postgres.js",
+    "db:smoke": "node scripts/smoke-data-layer.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/new/scripts/setup-postgres.js
+++ b/backend/new/scripts/setup-postgres.js
@@ -22,11 +22,19 @@ async function main() {
 
   try {
     await client.query(sql);
+    const departments = await client.query(
+      "SELECT COUNT(*)::int AS count FROM departments"
+    );
     const cases = await client.query("SELECT COUNT(*)::int AS count FROM cases");
     const users = await client.query("SELECT COUNT(*)::int AS count FROM users");
+    const events = await client.query(
+      "SELECT COUNT(*)::int AS count FROM case_events"
+    );
     console.log("PostgreSQL schema applied.");
-    console.log(`cases rows: ${cases.rows[0].count}`);
+    console.log(`departments rows: ${departments.rows[0].count}`);
     console.log(`users rows: ${users.rows[0].count}`);
+    console.log(`cases rows: ${cases.rows[0].count}`);
+    console.log(`case_events rows: ${events.rows[0].count}`);
   } finally {
     await client.end();
   }

--- a/backend/new/scripts/smoke-data-layer.js
+++ b/backend/new/scripts/smoke-data-layer.js
@@ -1,0 +1,74 @@
+/**
+ * Smoke-test the Postgres data layer without touching Mongo / server.js.
+ * Usage: node scripts/smoke-data-layer.js
+ */
+require("dotenv").config();
+
+const db = require("../db");
+
+async function main() {
+  const ping = await db.pool.ping();
+  console.log("ping", ping.now);
+
+  const departments = await db.departments.listDepartments();
+  console.log(
+    "departments",
+    departments.length,
+    departments.map((d) => d.name).join(", ")
+  );
+
+  const users = await db.users.listUsers({ activeOnly: false });
+  console.log("users", users.length);
+
+  const created = await db.cases.createCase({
+    title: "Maintenance Case",
+    category: "Maintenance",
+    status: "ACTIVE",
+    locationX: 0.5,
+    locationY: 0.5,
+    locationLabel: "Cafeteria",
+    createdByUserId: 7,
+    description: "Broken tap (data-layer smoke test)",
+  });
+  console.log("created case", created.id, created.category, created.status);
+
+  const assigned = await db.cases.assignCase(created.id, {
+    departmentId: 6,
+    userId: 5,
+    actorUserId: 3,
+  });
+  console.log(
+    "assigned",
+    assigned.assignedDepartmentName,
+    assigned.assignedUserName,
+    assigned.status
+  );
+
+  const closed = await db.cases.closeCase(created.id, { actorUserId: 5 });
+  console.log("closed", closed.status, closed.closedAt);
+
+  const analytics = await db.cases.analyticsSummary();
+  console.log("analytics", {
+    active: analytics.active,
+    closed: analytics.closed,
+    total: analytics.total,
+  });
+
+  await db.cases.deleteCase(created.id);
+  console.log("smoke case deleted");
+}
+
+main()
+  .then(async () => {
+    await db.pool.pool.end();
+    process.exit(0);
+  })
+  .catch(async (err) => {
+    console.error("data-layer smoke failed:", err.message);
+    try {
+      await db.pool.pool.end();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  });


### PR DESCRIPTION
Introduce a Postgres data layer at backend/new/db: pool, mappers, and query modules for cases, users, and departments. Add an idempotent schema (departments, users extended, cases, case_events) with seed rows and indexes, plus scripts/setup-postgres logging table counts. Add smoke-data-layer script and npm script db:smoke to exercise create/assign/close flows. Update README docs to describe the new Postgres foundation and clarify that server.js still uses Mongo until routes are switched.