### PR TITLE
Fix frontend JWT API integration

### DIFF
--- a/expo-app/lib/api.ts
+++ b/expo-app/lib/api.ts
@@ -47,6 +47,7 @@ export function getAccessResponsibilities(authorisation?: number): string[] {
 }
 
 const SESSION_KEY = "sentinel.currentUserId";
+const TOKEN_KEY = "sentinel.authToken";
 const DEFAULT_EXPRESS = "http://localhost:3000";
 const DEFAULT_FLASK = "http://localhost:5000";
 
@@ -67,6 +68,7 @@ export const EXPRESS_URL = resolveUrl("EXPO_PUBLIC_API_URL", DEFAULT_EXPRESS);
 export const FLASK_URL = resolveUrl("EXPO_PUBLIC_FLASK_URL", DEFAULT_FLASK);
 
 let currentUserId = 1;
+let authToken: string | null = null;
 let sessionHydrated = false;
 
 export function getCurrentUserId(): number {
@@ -79,29 +81,63 @@ export function setCurrentUserId(id: number): void {
 
 export async function hydrateSession(): Promise<number> {
   if (sessionHydrated) return currentUserId;
+
   try {
-    const raw = await AsyncStorage.getItem(SESSION_KEY);
-    if (raw) {
-      const parsed = Number(raw);
+    const [rawUserId, storedToken] = await Promise.all([
+      AsyncStorage.getItem(SESSION_KEY),
+      AsyncStorage.getItem(TOKEN_KEY),
+    ]);
+
+    if (rawUserId) {
+      const parsed = Number(rawUserId);
       if (!Number.isNaN(parsed) && parsed > 0) currentUserId = parsed;
     }
+
+    authToken = storedToken;
   } catch {
-    // keep default
+    // keep defaults
   }
+
   sessionHydrated = true;
   return currentUserId;
 }
 
-export async function persistSession(id: number): Promise<void> {
+export async function persistSession(
+  id: number,
+  token?: string
+): Promise<void> {
   currentUserId = id;
   sessionHydrated = true;
+
   await AsyncStorage.setItem(SESSION_KEY, String(id));
+
+  if (token) {
+    authToken = token;
+    await AsyncStorage.setItem(TOKEN_KEY, token);
+  }
 }
 
 export async function clearSession(): Promise<void> {
   currentUserId = 1;
+  authToken = null;
   sessionHydrated = true;
-  await AsyncStorage.removeItem(SESSION_KEY);
+
+  await Promise.all([
+    AsyncStorage.removeItem(SESSION_KEY),
+    AsyncStorage.removeItem(TOKEN_KEY),
+  ]);
+}
+
+export async function getAuthToken(): Promise<string | null> {
+  if (authToken) return authToken;
+
+  try {
+    authToken = await AsyncStorage.getItem(TOKEN_KEY);
+  } catch {
+    authToken = null;
+  }
+
+  return authToken;
 }
 
 async function request<T>(
@@ -113,10 +149,13 @@ async function request<T>(
   const timeout = setTimeout(() => controller.abort(), 8000);
 
   try {
+    const token = await getAuthToken();
+
     const res = await fetch(`${base}${path}`, {
       ...init,
       headers: {
         "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...(init?.headers ?? {}),
       },
       signal: controller.signal,
@@ -139,8 +178,11 @@ export async function getUsers(): Promise<User[]> {
 }
 
 export async function getUser(id: number): Promise<User | null> {
-  const users = await getUsers();
-  return users.find((u) => u.id === id) ?? null;
+  try {
+    return await request<User>(EXPRESS_URL, `/users/${id}`);
+  } catch {
+    return null;
+  }
 }
 
 export async function updateUser(
@@ -166,28 +208,34 @@ export function getUserPhone(user: User): string {
   return user.phone ?? user["phone number"] ?? "";
 }
 
+type LoginResponse = {
+  token: string;
+  user: User;
+};
+
 export async function loginWithEmailPassword(
   email: string,
   password: string
 ): Promise<User> {
-  const users = await getUsers();
-  const normalized = email.trim().toLowerCase();
-  const user = users.find(
-    (u) =>
-      u.email?.toLowerCase() === normalized &&
-      (u.password ?? "") === password
-  );
-  if (!user) {
-    throw new Error("Invalid email or password.");
+  const result = await request<LoginResponse>(EXPRESS_URL, "/auth/login", {
+    method: "POST",
+    body: JSON.stringify({
+      email: email.trim(),
+      password,
+    }),
+  });
+
+  if (!result?.token || !result?.user?.id) {
+    throw new Error("Invalid login response from API.");
   }
-  await persistSession(user.id);
-  return user;
+
+  await persistSession(result.user.id, result.token);
+  return result.user;
 }
 
 export async function checkExpressHealth(): Promise<HealthStatus> {
   try {
-    // New Mongo cases API is the primary ticketing backend
-    await request<unknown>(EXPRESS_URL, "/cases");
+    await request<unknown>(EXPRESS_URL, "/health");
     return { ok: true, message: "Connected" };
   } catch (error) {
     const message =

--- a/expo-app/lib/db.ts
+++ b/expo-app/lib/db.ts
@@ -1,3 +1,5 @@
+import { getAuthToken } from "./api";
+
 const API =
   (process.env.EXPO_PUBLIC_API_URL || "http://localhost:3000").replace(
     /\/$/,
@@ -7,7 +9,16 @@ const API =
 async function requestJson(path: string, init?: RequestInit) {
   let response: Response;
   try {
-    response = await fetch(`${API}${path}`, init);
+    const token = await getAuthToken();
+
+    response = await fetch(`${API}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(init?.headers ?? {}),
+      },
+    });
   } catch (error) {
     throw new Error(
       `Cannot reach API at ${API}${path}. Is backend/new running? (${


### PR DESCRIPTION
Fixes the frontend API integration after the backend authentication changes.

Changes:
- use POST /auth/login instead of fetching /users for client-side password validation
- persist JWT in AsyncStorage
- attach Authorization Bearer token to protected Users and Cases requests
- clear JWT on logout
- use /users/:id for profile loading
- use /health for API health checks instead of protected /cases

Validated locally:
- login succeeds with authenticated API
- Dashboard loads cases
- Vault loads cases
- Settings loads authenticated user
- logout clears session and returns to login

Related to #16.