### PR TITLE
Fix analytics API client regression

### DIFF
--- a/expo-app/lib/api.ts
+++ b/expo-app/lib/api.ts
@@ -19,6 +19,22 @@ export type HealthStatus = {
   message: string;
 };
 
+export type AnalyticsSummary = {
+  active: number;
+  closed: number;
+  total: number;
+  avgDurationMs: number;
+  byCategory: { category: string; count: number }[];
+  hotspots: { label: string; count: number }[];
+  servicesContacted: {
+    police: number;
+    fire: number;
+    ambulance: number;
+    maintenance: number;
+  };
+};
+
+
 /** authorisation 1 = site lead / higher priority; 2 = standard staff */
 export function getAccessLevelLabel(authorisation?: number): string {
   if (authorisation === 1) return "Priority / Lead";
@@ -231,6 +247,10 @@ export async function loginWithEmailPassword(
 
   await persistSession(result.user.id, result.token);
   return result.user;
+}
+
+export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
+  return request<AnalyticsSummary>(EXPRESS_URL, "/cases/analytics");
 }
 
 export async function checkExpressHealth(): Promise<HealthStatus> {


### PR DESCRIPTION
Restores the AnalyticsSummary type and getAnalyticsSummary API helper that were lost during later frontend merges.

Validated locally:
- Web export succeeds
- Authenticated Analytics loads PostgreSQL summary
- Dashboard and Vault continue loading protected data

Fixes the production runtime error: getAnalyticsSummary is not a function.