### PR TITLE
Fix Render PostgreSQL password migration

### DIFF
--- a/backend/new/package.json
+++ b/backend/new/package.json
@@ -12,7 +12,8 @@
     "db:setup": "node scripts/setup-postgres.js",
     "db:ping": "node scripts/ping-postgres.js",
     "db:smoke": "node scripts/smoke-data-layer.js",
-    "db:smoke-attachments": "node scripts/smoke-attachments.js"
+    "db:smoke-attachments": "node scripts/smoke-attachments.js",
+    "db:hash-seeds": "node scripts/hashSeedPasswords.js"
   },
   "keywords": [],
   "author": "",

--- a/render.yaml
+++ b/render.yaml
@@ -11,6 +11,7 @@ services:
     plan: free
     rootDir: backend/new
     buildCommand: npm install
+    preDeployCommand: npm run db:setup && npm run db:hash-seeds
     startCommand: npm start
     healthCheckPath: /health
     envVars:


### PR DESCRIPTION
Ensures the Render deployment prepares PostgreSQL before starting the API.

Changes:
- adds db:hash-seeds npm script
- runs db:setup and db:hash-seeds as Render pre-deploy commands

Validated locally:
- db:setup succeeds
- first password migration converted 7 plaintext seed passwords
- second migration converted 0 and skipped all 8 bcrypt hashes, confirming idempotency

This addresses production /auth/login returning 500 while PostgreSQL health remains connected.